### PR TITLE
Update xmldom to v.7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flourish/saml2-js",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "SAML 2.0 node helpers",
   "author": "Clever",
   "license": "Apache-2.0",
@@ -38,6 +38,6 @@
     "xml-encryption": "^1.2.3",
     "xml2js": "^0.4.0",
     "xmlbuilder2": "^2.4.0",
-    "xmldom": "^0.5.0"
+    "xmldom": "github:xmldom/xmldom#0.7.0"
   }
 }


### PR DESCRIPTION
Updates xmldom to v.7.0.0 that fixes an XML input vulnerability (see https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q for more info on the issue).

It's installed via the release on GitHub rather than NPM, as the repo maintainers haven't been able to republish the package to NPM yet (see https://github.com/xmldom/xmldom/discussions/270#discussioncomment-1080132).

Once this is merged we can merge [#4043](https://github.com/kiln/flourish/pull/4043) to address the npm security warnings for this and a couple of the other platform server dependencies.